### PR TITLE
feat: select primitive options support

### DIFF
--- a/__tests__/select.test.js
+++ b/__tests__/select.test.js
@@ -215,7 +215,7 @@ describe('Select', () => {
 
   describe('can have custom optionValue', () => {
 
-    beforeAll(() => {
+    test('correct value is resolved - object option', () => {
       wrapper = mount(VntSelect, {
         propsData: {
           optionValue: 'id',
@@ -228,11 +228,21 @@ describe('Select', () => {
 
       const option = wrapper.find('.vnt-dropdown-options__item');
       option.trigger('click');
-    });
-
-    test('correct value is resolved', () => {
       const [[newValue]] = wrapper.emitted()['input'];
       expect(newValue).toBe(123);
+    });
+
+    test('correct value is resolved - primitive option', () => {
+      wrapper = mount(VntSelect, {
+        propsData: {
+          options: [ 'List item 1', 'List item 2']
+        }
+      });
+
+      const option = wrapper.find('.vnt-dropdown-options__item');
+      option.trigger('click');
+      const [[newValue]] = wrapper.emitted()['input'];
+      expect(newValue).toBe('List item 1');
     });
 
   });

--- a/docs/.vuepress/components/select-object.vue
+++ b/docs/.vuepress/components/select-object.vue
@@ -19,13 +19,13 @@ export default {
     return {
       country: null,
       countries: [
-        'Australia',
-        'Belgium',
-        'Canada',
-        'Germany',
-        'France',
-        'United Kingdom',
-        'United States'
+        { label: 'Australia', value: 'AUS' },
+        { label: 'Belgium', value: 'BEL' },
+        { label: 'Canada', value: 'CAN' },
+        { label: 'Germany', value: 'GER' },
+        { label: 'France', value: 'FRA' },
+        { label: 'United Kingdom', value: 'GBR' },
+        { label: 'United States', value: 'USA' }
       ]
     }
   }

--- a/src/components/dropdown/Options.vue
+++ b/src/components/dropdown/Options.vue
@@ -3,8 +3,8 @@
       class="vnt-dropdown-options"
       role="listbox">
 
-    <li v-for="option in options"
-        :key="getKey(option)"
+    <li v-for="(option, i) in options"
+        :key="i"
         class="vnt-dropdown-options__item"
         role="listitem"
         @click="selectOption(option)">{{ getText(option) }}</li>
@@ -53,10 +53,7 @@ export default {
     },
 
     getText(option) {
-      if (this.optionText) {
-        return option[this.optionText];
-      }
-      return option;
+      return typeof option === 'object' && this.optionText ? option[this.optionText] : option;
     },
 
     getValue(option) {

--- a/src/components/select/Select.vue
+++ b/src/components/select/Select.vue
@@ -89,7 +89,7 @@ export default {
       });
 
       if (!chosenOption) return '';
-      if (typeof chosenOption === 'object') return chosenOption[this.optionText]
+      if (typeof chosenOption === 'object') return chosenOption[this.optionText];
       return chosenOption;
     }
   },

--- a/src/components/select/Select.vue
+++ b/src/components/select/Select.vue
@@ -83,15 +83,21 @@ export default {
 
   computed: {
     chosenText() {
-      const chosenOption = this.options.find(option => option[this.optionValue] === this.value);
-      return chosenOption ? chosenOption[this.optionText] : '';
+      const chosenOption = this.options.find(option => {
+        if (typeof option === 'object') return option[this.optionValue] === this.value;
+        return option === this.value;
+      });
+
+      if (!chosenOption) return '';
+      if (typeof chosenOption === 'object') return chosenOption[this.optionText]
+      return chosenOption;
     }
   },
 
   methods: {
     selectValue(option) {
       if (!this.disabled) {
-        this.$emit('input', option[this.optionValue]);
+        this.$emit('input', typeof option === 'object' ? option[this.optionValue] : option);
       }
     },
 

--- a/stories/components/select.stories.js
+++ b/stories/components/select.stories.js
@@ -10,14 +10,33 @@ const countries = [
   { label: 'United States', value: 'USA' }
 ];
 
+const countriesPrimitive = [
+  'Australia',
+  'Belgium',
+  'Canada',
+  'Germany',
+  'France',
+  'United Kingdom',
+  'United States'
+];
+
 const createData = () => ({
   country: null,
   countries,
+  countriesPrimitive
 });
 
 /* eslint no-undef: 0 */
 storiesOf('Select', module)
   .add('default', () => ({
+    data: () => createData(),
+    template: `
+      <div style="width: 300px">
+        <vnt-select v-model="country" :options="countriesPrimitive"></vnt-select>
+        <p class="result">country: {{ country }}</p>
+      </div>`
+  }))
+  .add('object', () => ({
     data: () => createData(),
     template: `
       <div style="width: 300px">


### PR DESCRIPTION
Closes https://github.com/arturmiz/vuent/issues/107.

If merged, `VntSelect` will support both primitive and object `option` types.