### PR TITLE
fix(pivot): pivot-item active respects prop value (#115)

### DIFF
--- a/src/components/pivot/Pivot.vue
+++ b/src/components/pivot/Pivot.vue
@@ -75,7 +75,7 @@ export default {
       .filter(pivotItem => pivotItem.tag === 'vnt-pivot-item')
       .forEach((pivotItem, index) => {
         const attrs = pivotItem.data.attrs;
-        const isActive = Object.keys(attrs).indexOf('active') > -1;
+        const isActive = attrs && !!attrs.active
 
         const header = createElement('li', {
           staticClass: 'vnt-pivot__header',

--- a/stories/components/pivot.stories.js
+++ b/stories/components/pivot.stories.js
@@ -1,5 +1,15 @@
 import { storiesOf } from '@storybook/vue';
 
+const items = [
+  { label: 'Pivot 1', active: true, text: 'Lorem ipsum dolor sit amet enim. Etiam ullamcorper. Suspendisse a pellentesque dui, non felis. Maecenas malesuada elit lectus felis, malesuada ultricies. Curabitur et ligula. Ut molestie a, ultricies porta urna. Vestibulum commodo volutpat a, convallis ac, laoreet enim.' },
+  { label: 'Pivot 2', active: false, text: 'Phasellus fermentum in, dolor. Pellentesque facilisis. Nulla imperdiet sit amet magna. Vestibulum dapibus, mauris nec malesuada fames ac turpis velit, rhoncus eu, luctus et interdum adipiscing wisi. Aliquam erat ac ipsum. Integer aliquam purus.' },
+  { label: 'Pivot 3', active: false, text: 'Quisque lorem tortor fringilla sed, vestibulum id, eleifend justo vel bibendum sapien massa ac turpis faucibus orci luctus non, consectetuer lobortis quis, varius in, purus. Integer ultrices posuere cubilia Curae' }
+];
+
+const createData = () => ({
+  items
+});
+
 /* eslint no-undef: 0,
           no-unused-vars: 0 */
 storiesOf('Pivot', module)
@@ -26,4 +36,15 @@ storiesOf('Pivot', module)
       Determines which tab should be set as active.
       Must be added to \`vnt-pivot-item\` element that should be active at start.
     `
-  });
+  })
+  .add('active', () => ({
+    data: () => createData(),
+    template: `
+      <span>
+        <vnt-pivot>
+          <vnt-pivot-item v-for="item in items" :key="item.label" :label="item.label" :active="item.active">
+            <p>{{ item.text }}</p>
+          </vnt-pivot-item>
+        </vnt-pivot>
+      </span>`
+  }));


### PR DESCRIPTION
Modified the active property in pivot-items to respect the value of the property. This should allow for better support for loops.

Closes #115